### PR TITLE
Fix issue with query.hasOwnProperty described https://github.com/node…

### DIFF
--- a/notification-server.js
+++ b/notification-server.js
@@ -193,7 +193,7 @@ function handleHTTPCall(request, response) {
             let handler = handlerObject.handler;
             let password = handlerObject.password;
 
-            if (password && (!query.hasOwnProperty("password") || query.password !== password)) {
+            if (password && !query["password"] || query.password !== password)) {
                 response.writeHead(401, {'Content-Type': "text/html"});
                 response.write("Unauthorized");
                 response.end();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-http-notification-server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "An http/https server inside Homebridge to receive notifications from external programs",
   "license": "MIT",
   "main": "notification-server.js",


### PR DESCRIPTION
In this PR fix for error descibed bellow. 
[linked nodejs issue ](https://github.com/nodejs/node/pull/6289)
```
lib/node_modules/homebridge-http-notification-server/notification-server.js:196

            if (password && (!query.hasOwnProperty("password") || query.password !== password)) {
                                    ^
TypeError: query.hasOwnProperty is not a function
    at Server.handleHTTPCall (/home/vik/.nvm/versions/node/v8.9.1/lib/node_modules/homebridge-http-notification-server/notification-server.js:196:37)
    at emitTwo (events.js:126:13)
    at Server.emit (events.js:214:7)
    at parserOnIncoming (_http_server.js:602:12)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:117:23)